### PR TITLE
Fix errors

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -4,18 +4,29 @@ set -euo pipefail
 # Рабочая директория скрипта
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+CONFIG_FILE="${CONFIG_FILE:-app_config.toml}"
 # ===================== LOAD ENV =====================
 
 # Подгружаем .env и .env.local если они существуют
-if [ -f ".env" ]; then
-  # shellcheck disable=SC2046
-  export $(grep -v '^#' .env | xargs)
-fi
+set -a
+[ -f ".env" ] && source .env
+[ -f ".env.local" ] && source .env.local
+set +a
 
-if [ -f ".env.local" ]; then
-  # shellcheck disable=SC2046
-  export $(grep -v '^#' .env.local | xargs)
-fi
+# ===================== LOAD TOML CONFIG =====================
+eval "$(
+python3 - <<PY
+import tomllib
+
+with open("${CONFIG_FILE}", "rb") as f:
+    cfg = tomllib.load(f)["db"]
+
+print(f"DB_HOST={cfg['host']}")
+print(f"DB_PORT={cfg['port']}")
+print(f"DB_USER={cfg['user']}")
+print(f"DB_DATABASE={cfg['database']}")
+PY
+)"
 
 # ===================== CONFIG =====================
 

--- a/backup.sh
+++ b/backup.sh
@@ -19,12 +19,17 @@ python3 - <<PY
 import tomllib
 
 with open("${CONFIG_FILE}", "rb") as f:
-    cfg = tomllib.load(f)["db"]
+    cfg = tomllib.load(f)
+db = cfg["db"]
+core = cfg["core"]
 
-print(f"DB_HOST={cfg['host']}")
-print(f"DB_PORT={cfg['port']}")
-print(f"DB_USER={cfg['user']}")
-print(f"DB_DATABASE={cfg['database']}")
+#print(f"DB_HOST={db['host']}")
+print(f"DB_PORT={db['port']}")
+print(f"DB_USER={db['user']}")
+print(f"DB_DATABASE={db['database']}")
+
+admins = core.get("admin_ids", [])
+print("ADMIN_IDS=\"" + ",".join(map(str, admins)) + "\"")
 PY
 )"
 

--- a/bot/vpn/utils/mtproto.py
+++ b/bot/vpn/utils/mtproto.py
@@ -166,26 +166,58 @@ class MTProtoProxy:
         """
         return f"tg://proxy?server={self.client.host}&port={self.port}&secret={secret}"
 
-    async def get_secret(self) -> str:
-        """Получает MTProto secret из логов контейнера на хосте.
+    async def _fetch_secret(self) -> str | None:
+        """Получает MTProto secret из логов контейнера.
 
         Returns
-            str: Secret ключ MTProto.
-
-        Raises
-            AmneziaSSHError: Если не удалось получить или распарсить secret.
+            Найденный secret или ``None``, если получить его не удалось.
 
         """
-        cmd = f"docker logs {shlex.quote(self.container)} | grep 'EE-TLS' | awk -F'secret=' '{{print $2}}'"
-        stdout, stderr, code, _ = await self.client.write_single_cmd(cmd)
+        cmd = (
+            f"docker logs {shlex.quote(self.container)} 2>&1 "
+            "| grep 'EE-TLS' "
+            "| awk -F'secret=' '{print $2}'"
+        )
+        stdout, _, code, _ = await self.client.write_single_cmd(cmd)
+
         if code != 0 or not stdout:
-            raise AmneziaSSHError(
-                "Не удалось получить MTProto secret",
-                cmd=cmd,
-                stdout=stdout,
-                stderr=stderr,
-            )
-        return stdout.strip().splitlines()[-1].strip()
+            return None
+
+        secret = stdout.strip().splitlines()[-1].strip()
+        return secret or None
+
+    async def get_secret(self) -> str:
+        """Получает MTProto secret из логов контейнера.
+
+        Если secret отсутствует в логах, контейнер перезапускается и
+        выполняются повторные попытки чтения secret.
+
+        Returns
+            MTProto secret.
+
+        Raises
+            AmneziaSSHError: Если secret не удалось получить даже после
+                перезапуска контейнера.
+
+        """
+        secret = await self._fetch_secret()
+        if secret:
+            return secret
+        restart_cmd = f"docker restart {shlex.quote(self.container)}"
+        await self.client.write_single_cmd(restart_cmd)
+
+        await asyncio.sleep(5)
+
+        for _ in range(10):
+            secret = await self._fetch_secret()
+            if secret:
+                return secret
+            await asyncio.sleep(2)
+
+        raise AmneziaSSHError(
+            "Не удалось получить MTProto secret после перезапуска контейнера",
+            cmd=restart_cmd,
+        )
 
     async def get_proxy_link(self) -> str:
         """Формирует готовую ссылку для подключения MTProto proxy.


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Harden backup config loading and MTProto secret retrieval
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Make backup script load env safely and read DB settings from TOML.
• Add MTProto secret fetch retries with container restart fallback.
• Improve error handling to reduce flaky operations in production.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["backup.sh"] --> B["Load .env/.env.local"] --> C["Read app_config.toml"] --> D["Export DB_* + ADMIN_IDS"] --> E["Backup operations"]
  F["Bot MTProto utils"] --> G["SSH client cmd exec"] --> H["docker logs (EE-TLS)"] --> I["MTProto secret"] --> J["tg:// proxy link"]
  G --> K["docker restart"] --> H
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Use docker inspect / env instead of log scraping</b></summary>

- ➕ Less brittle than parsing logs with grep/awk
- ➕ Avoids reliance on specific log format (EE-TLS/secret=)
- ➖ May not expose the secret depending on container/image behavior
- ➖ Can require additional permissions or changes to container setup

</details>

<details>
<summary><b>2. Move config parsing into a dedicated config tool/library</b></summary>

- ➕ Avoids embedding python in bash; clearer dependency management
- ➕ Can support validation, defaults, and consistent mapping to env vars
- ➖ Adds a new runtime dependency/tooling step
- ➖ More refactor than a targeted fix if this is the only script needing it

</details>

**Recommendation:** Current approach is reasonable for a targeted reliability fix: the MTProto retry+restart loop reduces flakiness without large refactors, and the backup script’s `source`-based dotenv loading avoids unsafe `export $(...)`. The main follow-up to consider is hardening dependencies: `tomllib` requires Python 3.11+, so either ensure that’s guaranteed in the runtime environment or swap to a compatible parser/backport (e.g., `tomli`) and add explicit error messaging when TOML parsing fails.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>mtproto.py</strong> <code>Retry MTProto secret fetch with container restart fallback</code> <code>+45/-13</code></summary>

<br/>

>Retry MTProto secret fetch with container restart fallback
>
><pre>
>• Extracts log scraping into &#x27;_fetch_secret()&#x27; and updates &#x27;get_secret()&#x27; to restart the container and retry multiple times when the secret is missing. Improves error semantics by failing only after retries, raising a clearer &#x27;AmneziaSSHError&#x27; tied to the restart command.
></pre>
>
><a href='https://github.com/BoriskaGlebov/vpn_bot/pull/134/files#diff-597bf266c3c80d2176750e91b4366cf79549a56cbffdab0b79e6e22835f78d95'>bot/vpn/utils/mtproto.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>backup.sh</strong> <code>Load dotenv safely and derive backup env from TOML config</code> <code>+25/-9</code></summary>

<br/>

>Load dotenv safely and derive backup env from TOML config
>
><pre>
>• Replaces &#x27;export $(grep ...)&#x27; dotenv loading with &#x27;set -a&#x27; + &#x27;source&#x27; for &#x27;.env&#x27; and &#x27;.env.local&#x27;. Adds optional &#x27;CONFIG_FILE&#x27; (default &#x27;app_config.toml&#x27;) and a Python &#x27;tomllib&#x27; snippet to export DB and admin-related values into the environment.
></pre>
>
><a href='https://github.com/BoriskaGlebov/vpn_bot/pull/134/files#diff-611108f7b1232f3a7fd1c2d93d98284a7361a3cb2094f9e39354a922aabbc531'>backup.sh</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>