### PR TITLE
Фикс устаревающих Docker-volume поверх api/templates и sqladmin/statics

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -34,6 +34,11 @@ WORKDIR /vpn_bot
 
 
 
+# rsync нужен entrypoint.sh для атомарной синхронизации volume с шаблонами/статикой
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends rsync && \
+    rm -rf /var/lib/apt/lists/*
+
 # Устанавливаем Poetry
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir "poetry==$POETRY_VERSION"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -57,6 +57,14 @@ COPY --chown=botuser:bot shared/ shared/
 RUN cp -a api/templates api/templates_src && \
     chown -R botuser:bot api/templates_src
 
+# То же самое для статики sqladmin: volume в docker-compose монтируется
+# только в подпапку statics (не на весь пакет sqladmin — иначе volume
+# заморозил бы и сам код библиотеки на старой версии, игнорируя
+# обновления sqladmin через poetry.lock). Эталонная копия — вне зоны
+# volume-монтирования, синхронизируется entrypoint.sh при каждом старте.
+RUN cp -a /vpn_bot/.venv/lib/python3.12/site-packages/sqladmin/statics /vpn_bot/sqladmin_statics_src && \
+    chown -R botuser:bot /vpn_bot/sqladmin_statics_src
+
 # Делаем entrypoint исполняемым
 RUN chmod +x ./api/entrypoint.sh
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -49,6 +49,14 @@ COPY --chown=botuser:bot api/ api/
 COPY --chown=botuser:bot pyproject.toml poetry.lock alembic.ini app_config.toml app_config.develop.toml  ./
 COPY --chown=botuser:bot shared/ shared/
 
+# Эталонная копия шаблонов вне api/templates: в docker-compose поверх
+# api/templates монтируется именованный volume (чтобы шаблоны раздавал
+# nginx напрямую), а Docker не обновляет уже существующий volume при
+# пересборке образа. entrypoint.sh синхронизирует volume из этой копии
+# при каждом старте контейнера, чтобы volume не отставал от образа.
+RUN cp -a api/templates api/templates_src && \
+    chown -R botuser:bot api/templates_src
+
 # Делаем entrypoint исполняемым
 RUN chmod +x ./api/entrypoint.sh
 

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -5,6 +5,11 @@ echo "Выставляем корректные права на папку ло�
 mkdir -p /vpn_bot/api/logs
 chown -R botuser:bot /vpn_bot/api/logs
 
+echo "🔄 Синхронизация шаблонов в volume из образа..."
+rm -rf /vpn_bot/api/templates/*
+cp -a /vpn_bot/api/templates_src/. /vpn_bot/api/templates/
+chown -R botuser:bot /vpn_bot/api/templates
+
 echo "⚙️ Checking for Alembic migrations..."
 
 # Проверяем наличие alembic-конфигурации

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -6,14 +6,12 @@ mkdir -p /vpn_bot/api/logs
 chown -R botuser:bot /vpn_bot/api/logs
 
 echo "🔄 Синхронизация шаблонов в volume из образа..."
-rm -rf /vpn_bot/api/templates/*
-cp -a /vpn_bot/api/templates_src/. /vpn_bot/api/templates/
+rsync -a --delete --delay-updates /vpn_bot/api/templates_src/ /vpn_bot/api/templates/
 chown -R botuser:bot /vpn_bot/api/templates
 
 echo "🔄 Синхронизация статики sqladmin в volume из образа..."
 SQLADMIN_STATICS=/vpn_bot/.venv/lib/python3.12/site-packages/sqladmin/statics
-rm -rf "$SQLADMIN_STATICS"/*
-cp -a /vpn_bot/sqladmin_statics_src/. "$SQLADMIN_STATICS/"
+rsync -a --delete --delay-updates /vpn_bot/sqladmin_statics_src/ "$SQLADMIN_STATICS/"
 chown -R botuser:bot "$SQLADMIN_STATICS"
 
 echo "⚙️ Checking for Alembic migrations..."

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -10,6 +10,12 @@ rm -rf /vpn_bot/api/templates/*
 cp -a /vpn_bot/api/templates_src/. /vpn_bot/api/templates/
 chown -R botuser:bot /vpn_bot/api/templates
 
+echo "🔄 Синхронизация статики sqladmin в volume из образа..."
+SQLADMIN_STATICS=/vpn_bot/.venv/lib/python3.12/site-packages/sqladmin/statics
+rm -rf "$SQLADMIN_STATICS"/*
+cp -a /vpn_bot/sqladmin_statics_src/. "$SQLADMIN_STATICS/"
+chown -R botuser:bot "$SQLADMIN_STATICS"
+
 echo "⚙️ Checking for Alembic migrations..."
 
 # Проверяем наличие alembic-конфигурации

--- a/docker-compose.common.yml
+++ b/docker-compose.common.yml
@@ -28,7 +28,7 @@ services:
       TZ: Europe/Moscow
     volumes:
       - api_bot_logs:/vpn_bot/api/logs
-      - static_files1:/vpn_bot/.venv/lib/python3.12/site-packages/sqladmin
+      - static_files1:/vpn_bot/.venv/lib/python3.12/site-packages/sqladmin/statics
       - static_files2:/vpn_bot/api/templates
     deploy:
       resources:

--- a/nginx.conf
+++ b/nginx.conf
@@ -104,7 +104,7 @@ server {
     # Статические файлы
     # -----------------------------------------------------
     location /api/admin/statics/ {
-        alias /usr/src/app/static/statics/;
+        alias /usr/src/app/static/;
         autoindex off;
         try_files $uri =404;
         access_log off;

--- a/nginx_test.conf
+++ b/nginx_test.conf
@@ -18,7 +18,7 @@ http {
 
         # 📁 Раздача статики
         location /api/admin/statics/ {
-            alias /usr/src/app/static/statics/;
+            alias /usr/src/app/static/;
             autoindex on;
         }
 


### PR DESCRIPTION
## Проблема 1: api/templates
После деплоя `admin/dashboard.html` не находится (`TemplateNotFound`), хотя файл есть в git. Причина: `docker-compose.common.yml` монтирует именованный volume `static_files2` поверх `api/templates` (чтобы шаблоны напрямую раздавал nginx), а Docker не обновляет уже существующий volume при пересборке образа — новые файлы в нём просто не появляются.

## Проблема 2: sqladmin volume накрывал весь пакет, а не только статику
`static_files1` монтировался поверх **всего** пакета `sqladmin` (включая `.py`-файлы самой библиотеки), а не только его статики. Из-за этого при обновлении `sqladmin` (например, через Dependabot) в volume оставалась бы старая версия кода библиотеки даже после пересборки образа — обновление зависимости из `poetry.lock` реального эффекта бы не имело.

## Фикс
Для обеих директорий один и тот же приём: эталонная копия зашивается в образ отдельно (`api/templates_src`, `sqladmin_statics_src` — вне зоны действия volume-монтирования), и `api/entrypoint.sh` при каждом старте контейнера перезаписывает volume этой копией.

Заодно `static_files1` теперь монтируется только в `sqladmin/statics` (не в весь пакет) — `nginx.conf`/`nginx_test.conf` поправлены под новый путь (`alias` теперь указывает прямо на корень volume, без лишнего `/statics/`).

## Проверено
Локально собрал `api/Dockerfile`, для обеих директорий смоделировал "устаревший" volume (создал volume, положил в него старое/чужеродное содержимое — воспроизвёл ровно баг с прода) и прогнал синк из entrypoint — актуальное содержимое восстанавливается, при этом `.py`-файлы `sqladmin` volume’ом больше не накрываются. `nginx -t` не упал на изменённом `alias` (упал дальше, на отсутствующих в тестовом окружении SSL-сертификатах/апстримах — это ожидаемо и не связано с правкой).